### PR TITLE
Refactor: integrate cobra

### DIFF
--- a/component_contribution/core/metabolic_model.py
+++ b/component_contribution/core/metabolic_model.py
@@ -129,7 +129,7 @@ class MetabolicModel(object):
 
         compound_ids = set()
         for reaction in kegg_reactions:
-            compound_ids = compound_ids.union(reaction.stoichiometry.keys())
+            compound_ids = compound_ids.union(reaction.compound_ids)
         
         # convert the list of reactions in sparse notation into a full
         # stoichiometric matrix, where the rows (compounds) are according to the

--- a/component_contribution/core/reaction.py
+++ b/component_contribution/core/reaction.py
@@ -69,7 +69,7 @@ class Reaction(CobraReaction):
             compound = compound_cache.get_compound(compound_id)
             stoichiometry[compound] = stoichiometry.get(compound_id, 0) + count
 
-        reaction = cls(database=database, reaction_id=reaction_id)
+        reaction = cls(reaction_id=reaction_id, database=database)
         reaction.add_metabolites(stoichiometry)
         return reaction
 

--- a/component_contribution/prediction_model/model.py
+++ b/component_contribution/prediction_model/model.py
@@ -119,9 +119,9 @@ class ComponentContributionModel(object):
         x_prime = []
         G_prime = []
 
-        for compound_id, coefficient in reaction.stoichiometry.items():
-            if compound_id in self.cids_joined:  # cids_joined is the list of cid used in the training data
-                i = cids.index(compound_id)
+        for compound, coefficient in reaction.metabolites.items():
+            if compound.id in self.cids_joined:  # cids_joined is the list of cid used in the training data
+                i = cids.index(compound.id)
                 x[i, 0] = coefficient
             else:
                 # Decompose the compound and calculate the 'formation energy'
@@ -134,8 +134,7 @@ class ComponentContributionModel(object):
                 # are not in cids_joined anyway.
                 x_prime.append(coefficient)
 
-                comp = self.ccache.get_compound(compound_id)
-                group_vec = smiles_to_group_vector(self.decomposer, comp.smiles_ph_7)
+                group_vec = smiles_to_group_vector(self.decomposer, compound.smiles_ph_7)
                 G_prime.append(group_vec.to_array())
 
         if len(x_prime) > 0:

--- a/component_contribution/prediction_model/model.py
+++ b/component_contribution/prediction_model/model.py
@@ -174,7 +174,7 @@ class ComponentContributionModel(object):
         try:
             x, g = self.decompose_reaction(reaction)
         except group_vector.GroupDecompositionError as e:
-            logger.warning("Failed to decompose reaction %s (%s)" % (reaction.reaction_id,  str(e)))
+            logger.warning("Failed to decompose reaction %s (%s)" % (reaction.id,  str(e)))
             if not include_analysis:
                 return 0, 1e5
             else:

--- a/component_contribution/prediction_model/model.py
+++ b/component_contribution/prediction_model/model.py
@@ -217,7 +217,11 @@ class ComponentContributionModel(object):
             for j in orders:
                 if abs(weights[0, j]) < 1e-5:
                     continue
-                r = Reaction({cids[i]: s_matrix[i, j] for i in range(s_matrix.shape[0]) if s_matrix[i, j] != 0})
+
+                stoichiometry = {self.ccache.get_compound(cids[i]): s_matrix[i, j] for i in
+                                 range(s_matrix.shape[0]) if s_matrix[i, j] != 0}
+                r = Reaction()
+                r.add_metabolites(stoichiometry)
                 analysis.append({'index': j, 'w_rc': weights_rc[0, j], 'w_gc': weights_gc[0, j],
                                  'reaction': r, 'count': int(S_count[0, j])})
 

--- a/component_contribution/prediction_model/training_data.py
+++ b/component_contribution/prediction_model/training_data.py
@@ -42,8 +42,8 @@ class TrainingData(object):
         # CID list 'cids'.
         self.S = np.zeros((len(cids), len(thermo_params)))
         for k, a in enumerate(thermo_params):
-            for compound_id, coefficient in a['reaction'].stoichiometry.items():
-                self.S[cids.index(compound_id), k] = coefficient
+            for compound, coefficient in a['reaction'].metabolites.items():
+                self.S[cids.index(compound.id), k] = coefficient
             
         self.cids = cids
 
@@ -254,8 +254,9 @@ class TrainingData(object):
         for k in reaction_indices_to_remove:
             stoichiometry = {}
             for i in np.nonzero(self.S[:, k])[0]:
-                stoichiometry[self.cids[i]] = self.S[i, k]
-            reaction = Reaction(stoichiometry)
+                stoichiometry[self.ccache.get_compound(self.cids[i])] = self.S[i, k]
+            reaction = Reaction()
+            reaction.add_metabolites(stoichiometry)
             logging.debug('unbalanced reaction #%d: %s' % (k, reaction.reaction))
             for j in np.where(conserved[:, k])[0].flat:
                 logging.debug('there are %d more %s atoms on the right-hand side' % (conserved[j, k], elements[j]))

--- a/component_contribution/prediction_model/training_data.py
+++ b/component_contribution/prediction_model/training_data.py
@@ -92,9 +92,10 @@ class TrainingData(object):
         csv_output = csv.writer(open(fname, 'w'))
         csv_output.writerow(['reaction', 'T', 'I', 'pH', 'reference', 'dG0', 'dG0_prime'])
         for j in range(self.S.shape[1]):
-            stoichiometry = {self.cids[i]: self.S[i, j] for i in range(self.S.shape[0])}
-            r_string = Reaction(stoichiometry).equation
-            csv_output.writerow([r_string, self.T[j], self.I[j], self.pH[j],
+            stoichiometry = {self.ccache.get_compound(self.cids[i]): self.S[i, j] for i in range(self.S.shape[0])}
+            reaction = Reaction(reaction_id="-")
+            reaction.add_metabolites(stoichiometry)
+            csv_output.writerow([reaction.reaction, self.T[j], self.I[j], self.pH[j],
                                  self.reference[j], self.dG0[j], self.dG0_prime[j]])
 
     @staticmethod
@@ -255,7 +256,7 @@ class TrainingData(object):
             for i in np.nonzero(self.S[:, k])[0]:
                 stoichiometry[self.cids[i]] = self.S[i, k]
             reaction = Reaction(stoichiometry)
-            logging.debug('unbalanced reaction #%d: %s' % (k, reaction.equation))
+            logging.debug('unbalanced reaction #%d: %s' % (k, reaction.reaction))
             for j in np.where(conserved[:, k])[0].flat:
                 logging.debug('there are %d more %s atoms on the right-hand side' % (conserved[j, k], elements[j]))
         

--- a/component_contribution/prediction_model/training_data.py
+++ b/component_contribution/prediction_model/training_data.py
@@ -93,7 +93,7 @@ class TrainingData(object):
         csv_output.writerow(['reaction', 'T', 'I', 'pH', 'reference', 'dG0', 'dG0_prime'])
         for j in range(self.S.shape[1]):
             stoichiometry = {self.ccache.get_compound(self.cids[i]): self.S[i, j] for i in range(self.S.shape[0])}
-            reaction = Reaction(reaction_id="-")
+            reaction = Reaction()
             reaction.add_metabolites(stoichiometry)
             csv_output.writerow([reaction.reaction, self.T[j], self.I[j], self.pH[j],
                                  self.reference[j], self.dG0[j], self.dG0_prime[j]])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ requirements = ['scipy>=0.14.0',
                 'numpy>=1.6.2',
                 'pandas>=0.21',
                 'bioservices>=1.5',
-                'requests>=2.18']
+                'requests>=2.18',
+                'cobra>=0.10']
 
 setup(
     name='component_contribution',


### PR DESCRIPTION
Compound and Reaction are now a subclass of cobra.Reaction and cobra.Metabolite.

For now I think does the trick. In the future, I think we can skip Compound and use the `annotation` to store the necessary data (InChI, InChI Key, smiles_at_ph7, number_of_protons, charges, etc.) using a controlled vocabulary. Either Enun (py3 only) or some equivalent library.